### PR TITLE
removed deprecated message vars for Moodle 4.5 compatibility 

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -29,8 +29,8 @@ $messageproviders = [
     // Notify teacher that a student has submitted a quiz attempt.
     'schedulednotification' => [
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED,
+            'email' => MESSAGE_PERMITTED,
         ],
     ]
 ];

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022030200;
+$plugin->version = 2025050800;
 $plugin->requires = 2019111800;
 $plugin->component = 'tool_coursewrangler';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
I have removed deprecated message vars for Moodle 4.5 compatibility. The plugin should now install on Moodle 4.5